### PR TITLE
add error checks

### DIFF
--- a/lib/s3-static-site.rb
+++ b/lib/s3-static-site.rb
@@ -1,6 +1,8 @@
 require 'haml'
 require 'aws/s3'
 
+MAX_RETRY_COUNT = 3
+
 unless Capistrano::Configuration.respond_to?(:instance)
   abort "s3-static-site requires Capistrano >= 2."
 end
@@ -65,7 +67,19 @@ Capistrano::Configuration.instance(true).load do
               open(file)
             end
 
-            AWS::S3::S3Object.store(path, contents, bucket, :access => :public_read)
+            success = false
+            MAX_RETRY_COUNT.times do
+              if AWS::S3::S3Object.store(path, contents, bucket, :access => :public_read)
+                success = true
+                break
+              end
+            end
+            unless success
+              puts "*****************WARNING****************" 
+              puts "Upload to s3 failed!"
+              puts "*****************WARNING****************" 
+            end
+
           end
         end
       end

--- a/lib/s3-static-site.rb
+++ b/lib/s3-static-site.rb
@@ -69,7 +69,7 @@ Capistrano::Configuration.instance(true).load do
 
             success = false
             MAX_RETRY_COUNT.times do
-              if AWS::S3::S3Object.store(path, contents, bucket, :access => :public_read)
+              if AWS::S3::S3Object.store(path, contents, bucket, :access => :public_read) && AWS::S3::S3Object.exists?(path, bucket)
                 success = true
                 break
               end


### PR DESCRIPTION
`AWS::S3::S3Object.store` returns false on error -- it does not throw exceptions.  You should definitely loop through and retry on failure.

Additionally, we witnessed that method fail silently.  That's pretty bad for us, so we added in a second error check, which you may or may not need.  (It adds another HTTP roundtrip for every file.)

Thanks for the gem!
