### PR TITLE
Use the rubylib Dir.pwd function

### DIFF
--- a/lib/s3-static-site.rb
+++ b/lib/s3-static-site.rb
@@ -10,7 +10,7 @@ Capistrano::Configuration.instance(true).load do
     set(name, *args, &block) if !exists?(name)
   end
   
-  _cset :deployment_path, `pwd`.gsub("\n", "") + "/public"
+  _cset :deployment_path, Dir.pwd.gsub("\n", "") + "/public"
   
   def base_file_path(file)
     file.gsub(deployment_path, "")


### PR DESCRIPTION
Shelling out to the to the pwd command (`pwd`) works on a number of popular
platforms, but does not work on Windows, and perhaps others.  The Dir.pwd
rubylib function should work everywhere.
