### PR TITLE
Add support for S3 write options

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -41,6 +41,16 @@ s3-static-site overrides the default Capistrano recipes for Rails projects with 
 
 Replace the +access_key_id+ and +secret_access_key+ from the values found in the AWS Management Console. 
 
+=== S3 write options
+
+s3-static-site sets files +:content_type+ and +:acl+ to +:public_read+, add or override with :
+
+  set :bucket_write_options, {
+    cache_control: "max-age=94608000, public"
+  }
+
+See aws-sdk S3Object.write:http://rubydoc.info/github/amazonwebservices/aws-sdk-for-ruby/master/AWS/S3/S3Object#write-instance_method documentation for all available options.
+
 == Create your bucket
 
 If you haven't already created a bucket for use with Amazon S3 static website hosting, you'll need to do this before deployment. Instructions can be found here:

--- a/lib/s3-static-site.rb
+++ b/lib/s3-static-site.rb
@@ -76,6 +76,7 @@ Capistrano::Configuration.instance(true).load do
                 :content_type => types[0]
               }
             end
+            options.merge!(bucket_write_options)
             _s3.buckets[bucket].objects[path].write(contents, options)
           end
         end


### PR DESCRIPTION
Simply allow custom S3 write option (ex. to set Cache-Control)
### S3 write options

s3-static-site sets files `:content_type` and `:acl` to `:public_read`, add or override with :

```
set :bucket_write_options, {
    cache_control: "max-age=94608000, public"
}
```

See aws-sdk [S3Object.write](http://rubydoc.info/github/amazonwebservices/aws-sdk-for-ruby/master/AWS/S3/S3Object#write-instance_method) documentation for all available options.
