### PR TITLE
Add support for deploy_to

### DIFF
--- a/lib/s3-static-site.rb
+++ b/lib/s3-static-site.rb
@@ -12,6 +12,7 @@ Capistrano::Configuration.instance(true).load do
   end
   
   _cset :deployment_path, Dir.pwd.gsub("\n", "") + "/public"
+  _cset :deploy_to, ""
   
   def base_file_path(file)
     file.gsub(deployment_path, "")
@@ -76,7 +77,7 @@ Capistrano::Configuration.instance(true).load do
                 :content_type => types[0]
               }
             end
-            _s3.buckets[bucket].objects[path].write(contents, options)
+            _s3.buckets[bucket].objects[File.join(deploy_to, path).gsub(/^\//)].write(contents, options)
           end
         end
       end

--- a/lib/s3-static-site.rb
+++ b/lib/s3-static-site.rb
@@ -77,7 +77,9 @@ Capistrano::Configuration.instance(true).load do
                 :content_type => types[0]
               }
             end
-            _s3.buckets[bucket].objects[File.join(deploy_to, path).gsub(/^\//)].write(contents, options)
+
+            target = deploy_to.empty? ? path : File.join(deploy_to, path)
+            _s3.buckets[bucket].objects[target].write(contents, options)
           end
         end
       end


### PR DESCRIPTION
Make s3-static-site respond to deploy_to so that it can deploy content to a path within a bucket other than the root.
