### PR TITLE
Use AWS-SDK default mechanism to find credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ s3-static-site overrides the default Capistrano recipes for Rails projects with 
     require 's3-static-site'
 
     set :bucket, "www.cool-website-bucket.com"
-    set :access_key_id, "CHANGETHIS"
-    set :secret_access_key, "CHANGETHIS"
 
 If you want to deploy to multiple buckets, have a look at
 [Capistrano multistage](https://github.com/capistrano/capistrano/wiki/2.x-Multistage-Extension)
 and  configure a bucket per stage configuration.
+
+AWS credentials are read from the environment. See the [AWS-SDK
+documentation](http://docs.aws.amazon.com/AWSSdkDocsRuby/latest/DeveloperGuide/set-up-creds.html)
+for details.
 
 #### S3 write options
 

--- a/lib/s3-static-site.rb
+++ b/lib/s3-static-site.rb
@@ -11,6 +11,9 @@ Capistrano::Configuration.instance(true).load do
     set(name, *args, &block) if !exists?(name)
   end
   
+  _cset :aws_connect_options, {}
+  _cset :access_key_id, nil
+  _cset :secret_access_key, nil
   _cset :deployment_path, Dir.pwd.gsub("\n", "") + "/public"
   _cset :deploy_to, ""
   
@@ -24,13 +27,14 @@ Capistrano::Configuration.instance(true).load do
   
   # Establishes the connection to Amazon S3
   def establish_connection!
-    # Send logging to STDOUT
-    AWS.config(:logger => Logger.new(STDOUT))
+    options = {
+      :logger => Logger.new(STDOUT) # Send logging to STDOUT
+    }.merge(aws_connect_options)
+    options[:access_key_id] = access_key_id if access_key_id
+    options[:secret_access_key] = secret_access_key if secret_access_key
 
-    AWS::S3.new(
-      :access_key_id => access_key_id,
-      :secret_access_key => secret_access_key
-    )
+    AWS.config(options)
+    AWS::S3.new
   end
   
   # Deployment recipes

--- a/s3-static-site.gemspec
+++ b/s3-static-site.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = "0.3.0"
 
   # Gem dependencies
-  gem.add_dependency("aws-sdk")
+  gem.add_dependency("aws-sdk", '~> 1.0', '>= 1.12.0')
   gem.add_dependency("capistrano")
   gem.add_dependency("haml")
   gem.add_dependency("mime-types")


### PR DESCRIPTION
AWS-SDK provides robust support for finding credentials in standard places in
the process's context, including well-known environment variables and EC2
metadata when IAM instance profiles are in use. Additionally, there are more
options that a user may want to specify to the `AWS.config()` method (e.g.
`:region`), which is possible now by set a hash value for the
`:aws_connect_options`.

Using these features together, it is possible also to explicitly assume an IAM
role in a capistrano configuration like this:

```
AWS.config
sts = AWS::STS.new
assumption = sts.assume_role({
        :role_arn => 'arn:aws:iam::012345678901:role/UpdateSite',
        :role_session_name => 's3-static-site',
        :duration_seconds => 900
})

set :aws_connect_options, assumption[:credentials]
```

The initial call to `AWS.config` uses credentials from the environment, and
then the gem will uses the credentials that result from the STS AssumeRole
call.
